### PR TITLE
Codice errore 00426 non esiste più

### DIFF
--- a/Validators/DatiTrasmissioneValidator.cs
+++ b/Validators/DatiTrasmissioneValidator.cs
@@ -34,10 +34,6 @@ namespace FatturaElettronica.Validators
             RuleFor(dt => dt.PECDestinatario)
                 .Length(7, 256)
                 .When(x => !string.IsNullOrEmpty(x.PECDestinatario));
-            RuleFor(x => x.PECDestinatario)
-                .Empty()
-                .When(x => x.CodiceDestinatario != "0000000")
-                .WithErrorCode("00426");
         }
     }
 }


### PR DESCRIPTION
Rimossa rule in quanto da specifiche tecniche versione 1.3 il codice errore 00426 è stato rimosso.

Allego link [https://www.agenziaentrate.gov.it/wps/wcm/connect/804f90d4-e678-41b5-8d43-785d807df229/Allegato+A+-+Specifiche+tecniche+vers+1.3.pdf?MOD=AJPERES&CACHEID=804f90d4-e678-41b5-8d43-785d807df229](url)