### PR TITLE
Added support for .NET Standard 2.0, improved validation performance.

### DIFF
--- a/FatturaElettronica.csproj
+++ b/FatturaElettronica.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <PackageId>FatturaElettronica</PackageId>
     <Authors>Nicola Iarocci</Authors>
     <Company>CIR 2000</Company>
@@ -25,10 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FatturaElettronica.Core" Version="1.0" />
+    <PackageReference Include="FatturaElettronica.Core" Version="1.0.1" />
     <PackageReference Include="FluentValidation" Version="8.0.100" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" Condition="$(TargetFramework) == 'netstandard1.1'" />
   </ItemGroup>
 
 </Project>

--- a/FatturaElettronica.csproj
+++ b/FatturaElettronica.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FatturaElettronica.Core" Version="1.0.1" />
+    <PackageReference Include="FatturaElettronica.Core" Version="1.1.0" />
     <PackageReference Include="FluentValidation" Version="8.0.100" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" Condition="$(TargetFramework) == 'netstandard1.1'" />

--- a/FatturaElettronicaExtensions.cs
+++ b/FatturaElettronicaExtensions.cs
@@ -1,18 +1,22 @@
 ﻿using System;
-using System.Reflection;
+using System.Collections.Concurrent;
+using FluentValidation;
 using FluentValidation.Results;
 
 namespace FatturaElettronica
 {
     public static class FatturaElettronicaExtensions
     {
-        public static ValidationResult Validate(this Common.BaseClassSerializable obj)
+        private static readonly ConcurrentDictionary<string, IValidator> ValidatorsCache = new ConcurrentDictionary<string, IValidator>();
+        public static ValidationResult Validate<T>(this T obj) where T : Common.BaseClassSerializable
         {
-            var type = Type.GetType(
-                string.Format("FatturaElettronica.Validators.{0}Validator", obj.GetType().Name));
-            var instance = Activator.CreateInstance(type);
-            var method = type.GetRuntimeMethod("Validate", new[] { obj.GetType() });
-            return (ValidationResult)method.Invoke(instance, new [] {obj} );
+            var validator = ValidatorsCache.GetOrAdd(typeof(T).Name, name =>
+            {
+                var type = Type.GetType($"FatturaElettronica.Validators.{name}Validator");
+                return (IValidator) Activator.CreateInstance(type);
+            });
+
+            return validator.Validate(obj);
         }
     }
 }

--- a/Tabelle/Tabella.cs
+++ b/Tabelle/Tabella.cs
@@ -1,16 +1,41 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace FatturaElettronica.Tabelle
 {
-    public abstract class Tabella
+    public abstract class Tabella : IEquatable<Tabella>
     {
+        private static readonly ConcurrentDictionary<string, HashSet<string>> CodiciCache = new ConcurrentDictionary<string, HashSet<string>>();
+
         public string Nome { get; set; }
-        public string Codice { get; set; }
+        public string Codice { get; protected set; }
         public string Descrizione { get { return Codice + " " + Nome; } }
-        public string[] Codici
+        public HashSet<string> Codici
         {
-            get { return List.Select(x => x.Codice).ToArray(); }
+            get { return CodiciCache.GetOrAdd(GetType().Name, n => new HashSet<string>(List.Select(l => l.Codice).Distinct())); }
         }
         public abstract Tabella[] List { get; }
+
+        public bool Equals(Tabella other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Codice, other.Codice);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((Tabella) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Codice?.GetHashCode() ?? 0;
+        }
     }
 }

--- a/Tabelle/Tabella.cs
+++ b/Tabelle/Tabella.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace FatturaElettronica.Tabelle
 {
-    public abstract class Tabella : IEquatable<Tabella>
+    public abstract class Tabella
     {
         private static readonly ConcurrentDictionary<string, HashSet<string>> CodiciCache = new ConcurrentDictionary<string, HashSet<string>>();
 
@@ -17,25 +17,5 @@ namespace FatturaElettronica.Tabelle
             get { return CodiciCache.GetOrAdd(GetType().Name, n => new HashSet<string>(List.Select(l => l.Codice).Distinct())); }
         }
         public abstract Tabella[] List { get; }
-
-        public bool Equals(Tabella other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Codice, other.Codice);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((Tabella) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return Codice?.GetHashCode() ?? 0;
-        }
     }
 }

--- a/Validators/IsValidValidator.cs
+++ b/Validators/IsValidValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FatturaElettronica.Tabelle;
 using FluentValidation.Validators;
 
@@ -6,14 +7,21 @@ namespace FatturaElettronica.Validators
 {
     public class IsValidValidator<T> : PropertyValidator where T : Tabella, new()
     {
+        private static readonly Lazy<T> DomainObjectLazy = new Lazy<T>(() => new T());
+
         public IsValidValidator() : base("'{PropertyName}' valori accettati: {AcceptedValues}") { }
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
             context.MessageFormatter.AppendArgument("AcceptedValues", string.Format(string.Join(", ", Domain)));
 
-            return Array.IndexOf(Domain, context.PropertyValue) != -1;
+            if (context.PropertyValue is string codice)
+            {
+                return Domain.Contains(codice);
+            }
+
+            return false;
         }
-        protected string[] Domain { get { return new T().Codici; } }
+        protected HashSet<string> Domain { get { return DomainObjectLazy.Value.Codici; } }
     }
 }


### PR DESCRIPTION
Oltre al supporto a .NET Standard 2.0 (Fix #119) ci sono alcuni commit che migliorano le performance dei vari `Validator`, utilizzando `HashSet<T>` e cache statiche ove possibile.

Ciò dovrebbe diminuire le allocazioni e alleggerire la pressione sul GC quando si utilizza la libreria in scenari di alta concorrenza (es. lato server).

Ditemi pure cosa ne pensate.