### PR TITLE
Aggiunto metodo FromXml(byte[])

### DIFF
--- a/Fattura.cs
+++ b/Fattura.cs
@@ -1,12 +1,10 @@
-﻿using System.Collections.Generic;
-using FatturaElettronica.Defaults;
-using FatturaElettronica.Common;
-using System.Xml.Serialization;
-using Newtonsoft.Json;
-using System.Xml;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System;
+using System.Xml;
+using FatturaElettronica.Common;
+using FatturaElettronica.Defaults;
 
 namespace FatturaElettronica
 {
@@ -39,10 +37,10 @@ namespace FatturaElettronica
         public void ReadXml(string xml)
         {
             var preambleByte = Encoding.UTF8.GetPreamble();
-            string _byteOrderMarkUtf8 = System.Text.Encoding.UTF8.GetString(preambleByte, 0, preambleByte.Length);
-            if (xml.StartsWith(_byteOrderMarkUtf8, StringComparison.Ordinal))
+            var byteOrderMarkUtf8 = System.Text.Encoding.UTF8.GetString(preambleByte, 0, preambleByte.Length);
+            if (xml.StartsWith(byteOrderMarkUtf8, StringComparison.Ordinal))
             {
-                int index = xml.IndexOf('<');
+                var index = xml.IndexOf('<');
                 if (index > 0)
                 {
                     xml = xml.Substring(index, xml.Length - index);

--- a/Fattura.cs
+++ b/Fattura.cs
@@ -34,8 +34,10 @@ namespace FatturaElettronica
             base.ReadXml(r);
         }
 
-        public void ReadXml(string xml)
+        public void ReadXml(byte[] b)
         {
+            var xml = Encoding.UTF8.GetString(b, 0, b.Length);
+
             var preambleByte = Encoding.UTF8.GetPreamble();
             var byteOrderMarkUtf8 = System.Text.Encoding.UTF8.GetString(preambleByte, 0, preambleByte.Length);
             if (xml.StartsWith(byteOrderMarkUtf8, StringComparison.Ordinal))

--- a/Fattura.cs
+++ b/Fattura.cs
@@ -1,21 +1,27 @@
 ﻿using System.Collections.Generic;
-using FatturaElettronica.Impostazioni;
+using FatturaElettronica.Defaults;
 using FatturaElettronica.Common;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
+using System.Xml;
+using System.IO;
+using System.Text;
+using System;
 
 namespace FatturaElettronica
 {
     public class Fattura : BaseClassSerializable
     {
-        protected Fattura() {
-            Header = new FatturaElettronicaHeader.Header();
-            Body = new List<FatturaElettronicaBody.Body>();
+        public Fattura()
+        {
+            FatturaElettronicaHeader = new FatturaElettronicaHeader.FatturaElettronicaHeader();
+            FatturaElettronicaBody = new List<FatturaElettronicaBody.FatturaElettronicaBody>();
         }
 
         public override void WriteXml(System.Xml.XmlWriter w)
         {
             w.WriteStartElement(RootElement.Prefix, RootElement.LocalName, RootElement.NameSpace);
-            w.WriteAttributeString("versione", Header.DatiTrasmissione.FormatoTrasmissione);
+            w.WriteAttributeString("versione", FatturaElettronicaHeader.DatiTrasmissione.FormatoTrasmissione);
             foreach (var a in RootElement.ExtraAttributes)
             {
                 w.WriteAttributeString(a.Prefix, a.LocalName, a.ns, a.value);
@@ -24,9 +30,28 @@ namespace FatturaElettronica
             w.WriteEndElement();
         }
 
-        public override void ReadXml(System.Xml.XmlReader r) {
+        public override void ReadXml(System.Xml.XmlReader r)
+        {
             r.MoveToContent();
             base.ReadXml(r);
+        }
+
+        public void ReadXml(string xml)
+        {
+            var preambleByte = Encoding.UTF8.GetPreamble();
+            string _byteOrderMarkUtf8 = System.Text.Encoding.UTF8.GetString(preambleByte, 0, preambleByte.Length);
+            if (xml.StartsWith(_byteOrderMarkUtf8, StringComparison.Ordinal))
+            {
+                int index = xml.IndexOf('<');
+                if (index > 0)
+                {
+                    xml = xml.Substring(index, xml.Length - index);
+                }
+            }
+
+            var r = XmlReader.Create(new StringReader(xml), new XmlReaderSettings { IgnoreWhitespace = true, IgnoreComments = true });
+
+            ReadXml(r);
         }
 
         public static Fattura CreateInstance(Instance formato)
@@ -36,11 +61,11 @@ namespace FatturaElettronica
             switch (formato)
             {
                 case Instance.PubblicaAmministrazione:
-                    f.Header.DatiTrasmissione.FormatoTrasmissione = FormatoTrasmissione.PubblicaAmministrazione;
+                    f.FatturaElettronicaHeader.DatiTrasmissione.FormatoTrasmissione = FormatoTrasmissione.PubblicaAmministrazione;
                     break;
                 case Instance.Privati:
-                    f.Header.DatiTrasmissione.FormatoTrasmissione = FormatoTrasmissione.Privati;
-                    f.Header.DatiTrasmissione.CodiceDestinatario = new string('0', 7);
+                    f.FatturaElettronicaHeader.DatiTrasmissione.FormatoTrasmissione = FormatoTrasmissione.Privati;
+                    f.FatturaElettronicaHeader.DatiTrasmissione.CodiceDestinatario = new string('0', 7);
                     break;
             }
 
@@ -55,8 +80,7 @@ namespace FatturaElettronica
         /// Intestazione della comunicazione.
         /// </summary>
         [DataProperty]
-        [XmlElement(ElementName = "FatturaElettronicaHeader")]
-        public FatturaElettronicaHeader.Header Header { get; }
+        public FatturaElettronicaHeader.FatturaElettronicaHeader FatturaElettronicaHeader { get; set; }
 
         /// <summary>
         /// Lotto di fatture incluse nella comunicazione.
@@ -64,8 +88,7 @@ namespace FatturaElettronica
         /// <remarks>Il blocco ha molteciplità 1 nel caso di fattura singola; nel caso di lotto di fatture, si ripete
         /// per ogni fattura componente il lotto stesso.</remarks>
         [DataProperty]
-        [XmlElement(ElementName = "FatturaElettronicaBody")]
-        public List<FatturaElettronicaBody.Body> Body { get; }
+        public List<FatturaElettronicaBody.FatturaElettronicaBody> FatturaElettronicaBody { get; set; }
 
     }
 }

--- a/Test/FatturaElettronica.Test.csproj
+++ b/Test/FatturaElettronica.Test.csproj
@@ -23,6 +23,9 @@
     <None Update="Samples\IT01234567890_FPR02.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Samples\IT01234567890_FPR03_BOM.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Test/Samples/IT01234567890_FPR03_BOM.xml
+++ b/Test/Samples/IT01234567890_FPR03_BOM.xml
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<p:FatturaElettronica versione="FPR12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 fatturaordinaria_v1.2.xsd ">
+  <FatturaElettronicaHeader>
+    <DatiTrasmissione>
+      <IdTrasmittente>
+        <IdPaese>IT</IdPaese>
+        <IdCodice>01234567890</IdCodice>
+      </IdTrasmittente>
+      <ProgressivoInvio>00001</ProgressivoInvio>
+      <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+      <CodiceDestinatario>0000000</CodiceDestinatario>
+      <ContattiTrasmittente/>
+      <PECDestinatario>betagamma@pec.it</PECDestinatario>
+    </DatiTrasmissione>
+    <CedentePrestatore>
+      <DatiAnagrafici>
+        <IdFiscaleIVA>
+          <IdPaese>IT</IdPaese>
+          <IdCodice>01234567890</IdCodice>
+        </IdFiscaleIVA>
+        <Anagrafica>
+          <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+          <Titolo>Titolo</Titolo>
+        </Anagrafica>
+        <RegimeFiscale>RF01</RegimeFiscale>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIALE ROMA 543</Indirizzo>
+        <CAP>07100</CAP>
+        <Comune>SASSARI</Comune>
+        <Provincia>SS</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CedentePrestatore>
+    <CessionarioCommittente>
+      <DatiAnagrafici>
+        <CodiceFiscale>09876543210</CodiceFiscale>
+        <Anagrafica>
+          <Denominazione>BETA GAMMA</Denominazione>
+          <Titolo>Titolo</Titolo>
+        </Anagrafica>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIA TORINO 38-B</Indirizzo>
+        <CAP>00145</CAP>
+        <Comune>ROMA</Comune>
+        <Provincia>RM</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CessionarioCommittente>
+  </FatturaElettronicaHeader>
+  <FatturaElettronicaBody>
+    <DatiGenerali>
+      <DatiGeneraliDocumento>
+        <TipoDocumento>TD01</TipoDocumento>
+        <Divisa>EUR</Divisa>
+        <Data>2014-12-18</Data>
+        <Numero>123</Numero>
+        <Causale>LA FATTURA FA RIFERIMENTO AD UNA OPERAZIONE AAAA BBBBBBBBBBBBBBBBBB CCC DDDDDDDDDDDDDDD E FFFFFFFFFFFFFFFFFFFF GGGGGGGGGG HHHHHHH II LLLLLLLLLLLLLLLLL MMM NNNNN OO PPPPPPPPPPP QQQQ RRRR SSSSSSSSSSSSSS</Causale>
+        <Causale>SEGUE DESCRIZIONE CAUSALE NEL CASO IN CUI NON SIANO STATI SUFFICIENTI 200 CARATTERI AAAAAAAAAAA BBBBBBBBBBBBBBBBB</Causale>
+      </DatiGeneraliDocumento>
+      <DatiOrdineAcquisto>
+        <RiferimentoNumeroLinea>1</RiferimentoNumeroLinea>
+        <IdDocumento>66685</IdDocumento>
+        <NumItem>1</NumItem>
+      </DatiOrdineAcquisto>
+      <DatiTrasporto>
+        <DatiAnagraficiVettore>
+          <IdFiscaleIVA>
+            <IdPaese>IT</IdPaese>
+            <IdCodice>24681012141</IdCodice>
+          </IdFiscaleIVA>
+          <Anagrafica>
+            <Denominazione>Trasporto spa</Denominazione>
+          </Anagrafica>
+        </DatiAnagraficiVettore>
+        <DataOraConsegna>2012-10-22T16:46:12.000+02:00</DataOraConsegna>
+      </DatiTrasporto>
+    </DatiGenerali>
+    <DatiBeniServizi>
+      <DettaglioLinee>
+        <NumeroLinea>1</NumeroLinea>
+        <Descrizione>LA DESCRIZIONE DELLA FORNITURA PUO' SUPERARE I CENTO CARATTERI CHE RAPPRESENTAVANO IL PRECEDENTE LIMITE DIMENSIONALE. TALE LIMITE NELLA NUOVA VERSIONE E' STATO PORTATO A MILLE CARATTERI</Descrizione>
+        <Quantita>5.00</Quantita>
+        <PrezzoUnitario>1.00</PrezzoUnitario>
+        <PrezzoTotale>5.00</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+      </DettaglioLinee>
+      <DettaglioLinee>
+        <NumeroLinea>2</NumeroLinea>
+        <Descrizione>FORNITURE VARIE PER UFFICIO</Descrizione>
+        <Quantita>10.00</Quantita>
+        <PrezzoUnitario>2.00</PrezzoUnitario>
+        <PrezzoTotale>20.00</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+      </DettaglioLinee>
+      <DettaglioLinee>
+        <NumeroLinea>3</NumeroLinea>
+        <Descrizione>TUBI RITORNO GASOLIO</Descrizione>
+        <Quantita>2.00</Quantita>
+        <UnitaMisura>Pezzo</UnitaMisura>
+        <PrezzoUnitario>5.00</PrezzoUnitario>
+        <ScontoMaggiorazione>
+          <Tipo>SC</Tipo>
+          <Importo>-1.71</Importo>
+        </ScontoMaggiorazione>
+        <PrezzoTotale>6.58</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+      </DettaglioLinee>
+      <DettaglioLinee>
+        <NumeroLinea>4</NumeroLinea>
+        <Descrizione>TUBI RITORNO GASOLIO</Descrizione>
+        <Quantita>1.00</Quantita>
+        <UnitaMisura>Pezzo</UnitaMisura>
+        <PrezzoUnitario>5.00</PrezzoUnitario>
+        <ScontoMaggiorazione>
+          <Tipo>SC</Tipo>
+          <Percentuale>10.0</Percentuale>
+        </ScontoMaggiorazione>
+        <PrezzoTotale>4.50</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+      </DettaglioLinee>
+      <DatiRiepilogo>
+        <AliquotaIVA>22.00</AliquotaIVA>
+        <ImponibileImporto>36.08</ImponibileImporto>
+        <Imposta>7.94</Imposta>
+        <EsigibilitaIVA>D</EsigibilitaIVA>
+      </DatiRiepilogo>
+    </DatiBeniServizi>
+    <DatiPagamento>
+      <CondizioniPagamento>TP01</CondizioniPagamento>
+      <DettaglioPagamento>
+        <ModalitaPagamento>MP01</ModalitaPagamento>
+        <DataScadenzaPagamento>2015-01-30</DataScadenzaPagamento>
+        <ImportoPagamento>36.08</ImportoPagamento>
+      </DettaglioPagamento>
+    </DatiPagamento>
+  </FatturaElettronicaBody>
+</p:FatturaElettronica>


### PR DESCRIPTION
Avevo la necessità di creare l'oggetto fattura elettronica a partire da un array di byte.

Ho usato il metodo ReadXml, trasformando l'array di byte in string e poi in XmlReader da passare al metodo ReadXml già esistente.

Ho avuto dei problemi con i file xml BOM, che alcuni software di fattura elettronica generano,
[https://it.wikipedia.org/wiki/Byte_Order_Mark](https://it.wikipedia.org/wiki/Byte_Order_Mark)), quindi questo metodo risolve i problemi con il BOM.
