### PR TITLE
Modifica PrezzoTotaleValidateAgainstError00423 in modo che rilevi errori di arrotondamento per PrezzoUnitario con più di 8 decimali

### DIFF
--- a/Test/DettaglioLineeValidator.cs
+++ b/Test/DettaglioLineeValidator.cs
@@ -146,6 +146,20 @@ namespace Tests
             challenge.Quantita = 1;
             challenge.PrezzoTotale = 1m;
             validator.ShouldNotHaveValidationErrorFor(x => x.PrezzoTotale, challenge);
+
+            //numero massimo di decimali
+            challenge.ScontoMaggiorazione.Clear();
+            challenge.PrezzoUnitario = 0.12345678m;
+            challenge.Quantita = 1000000000;
+            challenge.PrezzoTotale = challenge.PrezzoUnitario * challenge.Quantita.Value;
+            validator.ShouldNotHaveValidationErrorFor(x => x.PrezzoTotale, challenge);
+
+            //Errore 00423 per prezzo unitario per arrotondamento
+            challenge.ScontoMaggiorazione.Clear();
+            challenge.PrezzoUnitario = 0.123456789m;
+            challenge.Quantita = 10000000000;
+            challenge.PrezzoTotale = challenge.PrezzoUnitario * challenge.Quantita.Value;
+            validator.ShouldHaveValidationErrorFor(x => x.PrezzoTotale, challenge).WithErrorCode("00423");
         }
 
         [TestMethod]

--- a/Validators/DettaglioLineeValidator.cs
+++ b/Validators/DettaglioLineeValidator.cs
@@ -56,7 +56,7 @@ namespace FatturaElettronica.Validators
 
         private bool PrezzoTotaleValidateAgainstError00423(DettaglioLinee challenge)
         {
-            var prezzo = challenge.PrezzoUnitario;
+            var prezzo = Math.Round(challenge.PrezzoUnitario, 8);
             foreach (var sconto in challenge.ScontoMaggiorazione)
             {
 

--- a/Validators/DettaglioLineeValidator.cs
+++ b/Validators/DettaglioLineeValidator.cs
@@ -56,7 +56,7 @@ namespace FatturaElettronica.Validators
 
         private bool PrezzoTotaleValidateAgainstError00423(DettaglioLinee challenge)
         {
-            var prezzo = Math.Round(challenge.PrezzoUnitario, 8);
+            var prezzo = Math.Round(challenge.PrezzoUnitario, 8, MidpointRounding.AwayFromZero);
             foreach (var sconto in challenge.ScontoMaggiorazione)
             {
 


### PR DESCRIPTION
Modificata la verifica dell'erore 00423: il prezzo unitario viene arrotondata all'8 cifra decimale, in modo coerente con l'xsd, prima di venire moltiplicato per la quantità; in questo modo si scoprono i problemi di incongruenza con il totale dovuti a troppe cifre decimali ne prezzo unitario