### PR TITLE
Fix:CessionarioCommittente.AltriDatiIdentificativi della Fattura semplificata non è obbligatorio

### DIFF
--- a/Validators/Semplificata/CessionarioCommittenteValidator.cs
+++ b/Validators/Semplificata/CessionarioCommittenteValidator.cs
@@ -16,7 +16,9 @@ namespace FatturaElettronica.Validators.Semplificata
                 .When(x => x.AltriDatiIdentificativi == null);
 
             RuleFor(x => x.AltriDatiIdentificativi)
-                .SetValidator(new AltriDatiIdentificativiValidator());
+                .SetValidator(new AltriDatiIdentificativiValidator())
+                .When(x => x.AltriDatiIdentificativi != null || !x.AltriDatiIdentificativi.IsEmpty());
+            
 
             RuleFor(x => x.AltriDatiIdentificativi)
                 .NotEmpty()


### PR DESCRIPTION
Corretta la validazione di **CessionarioCommittente.AltriDatiIdentificativi**, per la Fattura semplificata questo elemento non è obbligatorio