### PR TITLE
Fix schemaLocation reference

### DIFF
--- a/Defaults.cs
+++ b/Defaults.cs
@@ -24,7 +24,7 @@
                 return new XmlAttributeString[] {
                     new XmlAttributeString { Prefix="xmlns", LocalName="ds", ns=null, value="http://www.w3.org/2000/09/xmldsig#"},
                     new XmlAttributeString { Prefix="xmlns", LocalName="xsi", ns=null, value="http://www.w3.org/2001/XMLSchema-instance"},
-                    new XmlAttributeString { Prefix="xsi", LocalName="schemaLocation", ns=null, value="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 fatturaordinaria_v1.2.xsd"}
+                    new XmlAttributeString { Prefix="xsi", LocalName="schemaLocation", ns=null, value="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2.1/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd"}
                 };
             }
         }


### PR DESCRIPTION
Set actual schema reference in order to avoid validation issues in some java client scenarios.
The schema might also be opted-in through a configuration property.