### PR TITLE
Add validations for decimal precisions as stated in xsd file

### DIFF
--- a/Extensions/DecimalRuleExtensions.cs
+++ b/Extensions/DecimalRuleExtensions.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+
+namespace FatturaElettronica.Extensions
+{
+    internal static class DecimalRuleExtensions
+    {
+        public static IRuleBuilderOptions<T, TProperty> ScalePrecision8DecimalType<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
+        {
+            return ruleBuilder.ScalePrecision(8, 19);
+        }
+        
+        public static IRuleBuilderOptions<T, TProperty> ScalePrecision2DecimalType<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
+        {
+            return ruleBuilder.ScalePrecision(2, 13);
+        }
+    }
+}

--- a/Test/BaseClass.cs
+++ b/Test/BaseClass.cs
@@ -198,5 +198,43 @@ namespace FatturaElettronica.Test
             var expr = (MemberExpression) outExpr.Body;
             return (PropertyInfo) expr.Member;
         }
+
+        protected void AssertDecimalType(Expression<Func<TClass, decimal?>> outExpr, int scale, int precision)
+        {
+            var maxValue = (decimal) Math.Pow(10, precision - scale) - 1;
+            var prop = GetProperty(outExpr);
+            prop.SetValue(Challenge,maxValue + 1);
+            Validator.ShouldHaveValidationErrorFor(outExpr, Challenge);
+            
+            prop.SetValue(Challenge,maxValue);
+            Validator.ShouldNotHaveValidationErrorFor(outExpr, Challenge);
+            
+            var decimalValueValid = (decimal)Math.Pow(10, -scale);
+            prop.SetValue(Challenge, decimalValueValid);
+            Validator.ShouldNotHaveValidationErrorFor(outExpr, Challenge);
+            
+            var decimalValueInvalid = (decimal)Math.Pow(10, -scale - 1);
+            prop.SetValue(Challenge, decimalValueInvalid);
+            Validator.ShouldHaveValidationErrorFor(outExpr, Challenge);
+        }
+        
+        protected void AssertDecimalType(Expression<Func<TClass, decimal>> outExpr, int scale, int precision)
+        {
+            var maxValue = (decimal) Math.Pow(10, precision - scale) - 1;
+            var prop = GetProperty(outExpr);
+            prop.SetValue(Challenge,maxValue + 1);
+            Validator.ShouldHaveValidationErrorFor(outExpr, Challenge);
+            
+            prop.SetValue(Challenge,maxValue);
+            Validator.ShouldNotHaveValidationErrorFor(outExpr, Challenge);
+            
+            var decimalValueValid = (decimal)Math.Pow(10, -scale);
+            prop.SetValue(Challenge, decimalValueValid);
+            Validator.ShouldNotHaveValidationErrorFor(outExpr, Challenge);
+            
+            var decimalValueInvalid = (decimal)Math.Pow(10, -scale - 1);
+            prop.SetValue(Challenge, decimalValueInvalid);
+            Validator.ShouldHaveValidationErrorFor(outExpr, Challenge);
+        }
     }
 }

--- a/Test/Common/ScontoMaggiorazioneValidator.cs
+++ b/Test/Common/ScontoMaggiorazioneValidator.cs
@@ -39,5 +39,11 @@ namespace FatturaElettronica.Test.Common
             Challenge.Percentuale = null;
             Validator.ShouldNotHaveValidationErrorFor(x => x.Tipo, Challenge);
         }
+        
+        [TestMethod]
+        public void Importo()
+        {
+            AssertDecimalType(x => x.Importo, 8, 19);
+        }
     }
 }

--- a/Test/Ordinaria/AltriDatiGestionaliValidator.cs
+++ b/Test/Ordinaria/AltriDatiGestionaliValidator.cs
@@ -42,5 +42,11 @@ namespace FatturaElettronica.Test.Ordinaria
         {
             AssertMustBeLatin1Supplement(x => x.RiferimentoTesto);
         }
+        
+        [TestMethod]
+        public void RiferimentoNumero()
+        {
+            AssertDecimalType(x => x.RiferimentoNumero, 8, 19);
+        }
     }
 }

--- a/Test/Ordinaria/DatiBolloValidator.cs
+++ b/Test/Ordinaria/DatiBolloValidator.cs
@@ -17,5 +17,11 @@ namespace FatturaElettronica.Test.Ordinaria
         {
             AssertOnlyAcceptsSIValue(x => x.BolloVirtuale);
         }
+        
+        [TestMethod]
+        public void ImportoBollo()
+        {
+            AssertDecimalType(x => x.ImportoBollo, 2, 13);
+        }
     }
 }

--- a/Test/Ordinaria/DatiCassaPrevidenzialeValidator.cs
+++ b/Test/Ordinaria/DatiCassaPrevidenzialeValidator.cs
@@ -71,5 +71,17 @@ namespace FatturaElettronica.Test.Ordinaria
         {
             AssertOnlyAcceptsSIValue(x => x.Ritenuta);
         }
+        
+        [TestMethod]
+        public void ImportoContributoCassa()
+        {
+            AssertDecimalType(x => x.ImportoContributoCassa, 2, 13);
+        }
+        
+        [TestMethod]
+        public void ImponibileCassa()
+        {
+            AssertDecimalType(x => x.ImponibileCassa, 2, 13);
+        }
     }
 }

--- a/Test/Ordinaria/DatiGeneraliDocumentoValidator.cs
+++ b/Test/Ordinaria/DatiGeneraliDocumentoValidator.cs
@@ -129,5 +129,17 @@ namespace FatturaElettronica.Test.Ordinaria
         {
             AssertOnlyAcceptsSIValue(x => x.Art73);
         }
+        
+        [TestMethod]
+        public void PenalitaPagamentiRitardati()
+        {
+            AssertDecimalType(x => x.ImportoTotaleDocumento, 2, 13);
+        }
+        
+        [TestMethod]
+        public void ImportoPagamento()
+        {
+            AssertDecimalType(x => x.Arrotondamento, 2, 13);
+        }
     }
 }

--- a/Test/Ordinaria/DatiRiepilogoValidator.cs
+++ b/Test/Ordinaria/DatiRiepilogoValidator.cs
@@ -90,5 +90,23 @@ namespace FatturaElettronica.Test.Ordinaria
         {
             AssertMustBeLatin1Supplement(x => x.RiferimentoNormativo);
         }
+        
+        [TestMethod]
+        public void SpeseAccessorie()
+        {
+            AssertDecimalType(x => x.SpeseAccessorie, 2, 13);
+        }
+        
+        [TestMethod]
+        public void ImponibileImporto()
+        {
+            AssertDecimalType(x => x.ImponibileImporto, 2, 13);
+        }
+        
+        [TestMethod]
+        public void Arrotondamento()
+        {
+            AssertDecimalType(x => x.Arrotondamento, 8, 19);
+        }
     }
 }

--- a/Test/Ordinaria/DatiRitenutaValidator.cs
+++ b/Test/Ordinaria/DatiRitenutaValidator.cs
@@ -30,5 +30,11 @@ namespace FatturaElettronica.Test.Ordinaria
         {
             AssertOnlyAcceptsTableValues<CausalePagamento>(x => x.CausalePagamento);
         }
+        
+        [TestMethod]
+        public void ImponibileImporto()
+        {
+            AssertDecimalType(x => x.ImportoRitenuta, 2, 13);
+        }
     }
 }

--- a/Test/Ordinaria/DettaglioLineeValidator.cs
+++ b/Test/Ordinaria/DettaglioLineeValidator.cs
@@ -267,5 +267,11 @@ namespace FatturaElettronica.Test.Ordinaria
             Challenge.Quantita = 0;
             Validator.ShouldNotHaveValidationErrorFor(x => x.Quantita, Challenge);
         }
+        
+        [TestMethod]
+        public void PrezzoUnitario()
+        {
+            AssertDecimalType(x => x.PrezzoUnitario, 8, 19);
+        }
     }
 }

--- a/Test/Ordinaria/DettaglioPagamentoValidator.cs
+++ b/Test/Ordinaria/DettaglioPagamentoValidator.cs
@@ -1,4 +1,6 @@
-﻿using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiPagamento;
+﻿using System;
+using System.Linq;
+using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiPagamento;
 using FatturaElettronica.Tabelle;
 using FluentValidation.TestHelper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -210,6 +212,24 @@ namespace FatturaElettronica.Test.Ordinaria
         public void CodicePagamentoMustBeBasicLatin()
         {
             AssertMustBeBasicLatin(x => x.CodicePagamento);
+        }
+
+        [TestMethod]
+        public void ScontoPagamentoAnticipato()
+        {
+            AssertDecimalType(x => x.ScontoPagamentoAnticipato, 2, 13);
+        }
+        
+        [TestMethod]
+        public void PenalitaPagamentiRitardati()
+        {
+            AssertDecimalType(x => x.PenalitaPagamentiRitardati, 2, 13);
+        }
+        
+        [TestMethod]
+        public void ImportoPagamento()
+        {
+            AssertDecimalType(x => x.ImportoPagamento, 2, 13);
         }
     }
 }

--- a/Validators/AltriDatiGestionaliValidator.cs
+++ b/Validators/AltriDatiGestionaliValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using FatturaElettronica.Extensions;
+using FluentValidation;
 using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiBeniServizi;
 
 namespace FatturaElettronica.Validators
@@ -15,6 +16,8 @@ namespace FatturaElettronica.Validators
                 .Length(1, 60)
                 .Latin1SupplementValidator()
                 .When(x => !string.IsNullOrEmpty(x.RiferimentoTesto));
+            RuleFor(x => x.RiferimentoNumero)
+                .ScalePrecision8DecimalType();
         }
     }
 }

--- a/Validators/DatiBolloValidator.cs
+++ b/Validators/DatiBolloValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using FatturaElettronica.Extensions;
+using FluentValidation;
 using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiGenerali;
 
 namespace FatturaElettronica.Validators
@@ -10,6 +11,8 @@ namespace FatturaElettronica.Validators
             RuleFor(x => x.BolloVirtuale)
                 .NotEmpty()
                 .Equal("SI");
+            RuleFor(x => x.ImportoBollo)
+                .ScalePrecision2DecimalType();
         }
     }
 }

--- a/Validators/DatiCassaPrevidenzialeValidator.cs
+++ b/Validators/DatiCassaPrevidenzialeValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using FatturaElettronica.Extensions;
+using FluentValidation;
 using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiGenerali;
 using FatturaElettronica.Tabelle;
 
@@ -33,6 +34,10 @@ namespace FatturaElettronica.Validators
                 .Length(1, 20)
                 .BasicLatinValidator()
                 .When(x=>!string.IsNullOrEmpty(x.RiferimentoAmministrazione));
+            RuleFor(x => x.ImportoContributoCassa)
+                .ScalePrecision2DecimalType();
+            RuleFor(x => x.ImponibileCassa)
+                .ScalePrecision2DecimalType();
         }
     }
 }

--- a/Validators/DatiGeneraliDocumentoValidator.cs
+++ b/Validators/DatiGeneraliDocumentoValidator.cs
@@ -44,6 +44,10 @@ namespace FatturaElettronica.Validators
             RuleFor(x => x.Art73)
                 .Equal("SI")
                 .When(x => !string.IsNullOrEmpty(x.Art73));
+            RuleFor(x => x.ImportoTotaleDocumento)
+                .ScalePrecision(2, 13);
+            RuleFor(x => x.Arrotondamento)
+                .ScalePrecision(2, 13);
         }
     }
 }

--- a/Validators/DatiRiepilogoValidator.cs
+++ b/Validators/DatiRiepilogoValidator.cs
@@ -2,6 +2,7 @@
 using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiBeniServizi;
 using FatturaElettronica.Tabelle;
 using System;
+using FatturaElettronica.Extensions;
 
 namespace FatturaElettronica.Validators
 {
@@ -37,6 +38,14 @@ namespace FatturaElettronica.Validators
                 .Length(1, 100)
                 .Latin1SupplementValidator()
                 .When(x => !string.IsNullOrEmpty(x.RiferimentoNormativo));
+            RuleFor(x => x.SpeseAccessorie)
+                .ScalePrecision2DecimalType();
+            RuleFor(x => x.ImponibileImporto)
+                .ScalePrecision2DecimalType();
+            RuleFor(x => x.Imposta)
+                .ScalePrecision2DecimalType();
+            RuleFor(x => x.Arrotondamento)
+                .ScalePrecision8DecimalType();
         }
         private bool ImpostaValidateAgainstError00421(DatiRiepilogo datiRiepilogo)
         {

--- a/Validators/DatiRitenutaValidator.cs
+++ b/Validators/DatiRitenutaValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using FatturaElettronica.Extensions;
+using FluentValidation;
 using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiGenerali;
 using FatturaElettronica.Tabelle;
 
@@ -14,6 +15,8 @@ namespace FatturaElettronica.Validators
             RuleFor(x => x.CausalePagamento)
                 .NotEmpty()
                 .SetValidator(new IsValidValidator<CausalePagamento>());
+            RuleFor(x => x.ImportoRitenuta)
+                .ScalePrecision2DecimalType();
         }
     }
 }

--- a/Validators/DettaglioLineeValidator.cs
+++ b/Validators/DettaglioLineeValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FatturaElettronica.Extensions;
 using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiBeniServizi;
 using FatturaElettronica.Tabelle;
 using FluentValidation;
@@ -51,6 +52,10 @@ namespace FatturaElettronica.Validators
                 .SetValidator(new AltriDatiGestionaliValidator());
             RuleFor(x => x.Quantita)
                 .GreaterThanOrEqualTo(0);
+            RuleFor(x => x.PrezzoUnitario)
+                .ScalePrecision8DecimalType();
+            RuleFor(x => x.PrezzoTotale)
+                .ScalePrecision8DecimalType();
         }
 
         private bool PrezzoTotaleValidateAgainstError00423(DettaglioLinee challenge)

--- a/Validators/DettaglioPagamentoValidator.cs
+++ b/Validators/DettaglioPagamentoValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using FatturaElettronica.Extensions;
+using FluentValidation;
 using FatturaElettronica.Ordinaria.FatturaElettronicaBody.DatiPagamento;
 using FatturaElettronica.Tabelle;
 
@@ -54,6 +55,12 @@ namespace FatturaElettronica.Validators
                 .Length(1, 60)
                 .BasicLatinValidator()
                 .When(x => !string.IsNullOrEmpty(x.CodicePagamento));
+            RuleFor(x => x.ScontoPagamentoAnticipato)
+                .ScalePrecision2DecimalType();
+            RuleFor(x => x.PenalitaPagamentiRitardati)
+                .ScalePrecision2DecimalType();
+            RuleFor(x => x.ImportoPagamento)
+                .ScalePrecision2DecimalType();
         }
     }
 }

--- a/Validators/ScontoMaggiorazioneValidator.cs
+++ b/Validators/ScontoMaggiorazioneValidator.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using FatturaElettronica.Common;
+using FatturaElettronica.Extensions;
 
 namespace FatturaElettronica.Validators
 {
@@ -14,6 +15,8 @@ namespace FatturaElettronica.Validators
                 .Must((challenge, _) => challenge.Importo != null || challenge.Percentuale != null)
                 .WithMessage("Percentuale e Importo non presenti a fronte di Tipo valorizzato")
                 .WithErrorCode("00437");
+            RuleFor(x => x.Importo)
+                .ScalePrecision8DecimalType();
         }
     }
 }


### PR DESCRIPTION
The XDS file https://www.agenziaentrate.gov.it/portale/documents/20143/2451019/Schema_VFPR12_29052020.xsd has rules for decimal values e.g. 2 faction digits and 11 number digits. This additions to validation prevents setting wrong decimal numbers that the online validator rejects. 