### PR TITLE
Getione del tag <?pi test?> prima del tag FatturaElettronicaHeader

### DIFF
--- a/Core/BaseClassSerializable.cs
+++ b/Core/BaseClassSerializable.cs
@@ -435,6 +435,7 @@ namespace FatturaElettronica.Core
         protected virtual void ReadAndHandleXmlStartElement(XmlReader r)
         {
             r.ReadStartElement();
+            if (r.NodeType == XmlNodeType.ProcessingInstruction) r.Skip();
         }
 
         /// <summary>


### PR DESCRIPTION
Mi è arrivata da gestire una FE così:
```
<p:FatturaElettronica xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 fatturaordinaria_v1.2.xsd" versione="FPR12">
    <?xml-stylesheet type="text/xsl"href="fatturaordinaria_v1.2.1.xslsl"?>
    <FatturaElettronicaHeader>
```
Il metodo ReadXml andava in errore _"'Element' is an invalid XmlNodeType."_