### PR TITLE
Remove Portable.BouncyCastle Dependency by Implementing Framework-Based Signature Parsing

### DIFF
--- a/Extensions/SignatureException.cs
+++ b/Extensions/SignatureException.cs
@@ -5,5 +5,9 @@ namespace FatturaElettronica.Extensions
     public class SignatureException : Exception
     {
         public SignatureException(string message) : base(message) { }
+
+        public SignatureException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
     }
 }

--- a/FatturaBase.cs
+++ b/FatturaBase.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Xml;
 using FatturaElettronica.Defaults;
 using FatturaElettronica.Extensions;
 using FatturaElettronica.Ordinaria;
-using Org.BouncyCastle.Cms;
 using BaseClassSerializable = FatturaElettronica.Core.BaseClassSerializable;
 
 namespace FatturaElettronica
@@ -96,7 +96,7 @@ namespace FatturaElettronica
                 newStream.Position = 0;
                 return CreateInstanceFromXml(newStream);
             }
-            catch (CmsException)
+            catch (CryptographicException)
             {
                 stream.Position = 0;
                 return CreateInstanceFromXmlSignedBase64(stream, validateSignature);

--- a/FatturaElettronica.csproj
+++ b/FatturaElettronica.csproj
@@ -35,7 +35,6 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.5.2"/>
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0"/>
     <PackageReference Include="System.Text.Json" Version="7.0.3"/>
   </ItemGroup>
 


### PR DESCRIPTION
feat(Cryptography): Replaced Portable.BouncyCastle CmsSignedData in SignedFileExtensions.ParseSignature with a framework implementation to eliminate the dependency